### PR TITLE
Add address to OpenFramesUntrustedData type

### DIFF
--- a/.changeset/cool-icons-hope.md
+++ b/.changeset/cool-icons-hope.md
@@ -1,0 +1,5 @@
+---
+"@open-frames/types": minor
+---
+
+add address type to untrusted data

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type OpenFramesUntrustedData = {
   buttonIndex: number;
   inputText?: string;
   state?: string;
+  address?: string;
 };
 
 export type OpenFramesTrustedData = {


### PR DESCRIPTION
Adds address to type as is required in spec for `tx` frames.